### PR TITLE
fixed reading cell value of null bug

### DIFF
--- a/workbook.js
+++ b/workbook.js
@@ -126,7 +126,7 @@
               if (range.e.c < C) range.e.c = C;
 
               var cell = (typeof data[R][C] == 'object' ? data[R][C] : {v: data[R][C] });
-              if (cell.v == null) continue;
+              if (cell == null || cell.v == null) continue;
               var cell_ref = encode_cell({c: C, r: R});
 
               if (typeof cell.v === 'number') cell.t = 'n';


### PR DESCRIPTION
Was previously getting this error, added extra null check and everything was dandy:

 if (cell.v == null) continue;
21:20:14 web.1  |                       ^
21:20:14 web.1  | TypeError: Cannot read property 'v' of null
21:20:14 web.1  |     at Object.Workbook._finalizeSheet (/Users/wen/sandbox/node_modules/workbook/workbook.js:129:23)
21:20:14 web.1  |     at /Users/wen/sandbox/node_modules/workbook/workbook.js:100:18
