### PR TITLE
Fixed the js-xlsx npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wrapper for [SheetJS/js-xlsx](https://github.com/SheetJS/js-xlsx) providing conv
 ## Install
 
 * `npm install workbook --save`
-* `npm install js-xlsx --save` 
+* `npm install xlsx --save` 
 
 Note that this can also wrap other versions of js-xlsx, e.g. [protobi/js-xlsx](https://github.com/SheetJS/js-xlsx), to allow application of styles using the `.s` attribute instead:
 


### PR DESCRIPTION
jx-xlsx npm link has changed when I checked in their GitHub. So I updated the npm command to install js-xlsx in README.md