### PR TITLE
Fixed example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ var workbook = new Workbook()
         {"v": 0.618033989},
         {"v": 0.618033989, "t": "n"},
         {"v": 0.618033989, "t": "n", "s": { "numFmt": "0.00%"}},
-        {"v": 0.618033989, "t": "n", "s": { "numFmt": "0.00%"}, fill: { fgColor: { rgb: "FFFFCC00"}}},
+        {"v": 0.618033989, "t": "n", "s": { "numFmt": "0.00%", fill: { fgColor: { rgb: "FFFFCC00"}}}},
         [(new Date()).toLocaleString()]
       ]
     ]).mergeCells("Main", {


### PR DESCRIPTION
"fill" parameter was in a separate curly braces than the other options to modify the cell, which caused xlsx-style to ignore the value.